### PR TITLE
Feature: Preserve UI fields when creating/uploading a release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,13 +10,14 @@ inputs:
   body:
     description: "Note-worthy description of changes in release"
     required: false
+    default: ${{ github.release.body }}
   body_path:
     description: "Path to load description of changes in this release"
     required: false
   name:
     description: "Gives the release a custom name. Defaults to tag name"
     required: false
-    default: ${{ github.ref_name }}
+    default: ${{ github.event.release.name }}
   tag_name:
     description: "Gives a tag name. Defaults to github.GITHUB_REF"
     required: false
@@ -27,6 +28,7 @@ inputs:
   prerelease:
     description: "Identify the release as a prerelease. Defaults to false"
     required: false
+    default: ${{ github.event.release.prerelease }}
   files:
     description: "Newline-delimited list of path globs for asset files to upload"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -10,14 +10,14 @@ inputs:
   body:
     description: "Note-worthy description of changes in release"
     required: false
-    default: ${{ github.release.body }}
+    default: ${{ github.event && gitub.event.release ? github.release.body : null }}
   body_path:
     description: "Path to load description of changes in this release"
     required: false
   name:
     description: "Gives the release a custom name. Defaults to tag name"
     required: false
-    default: ${{ github.event.release.name }}
+    default: ${{ github.event && gitub.event.release ? github.event.release.name : null }}
   tag_name:
     description: "Gives a tag name. Defaults to github.GITHUB_REF"
     required: false
@@ -28,7 +28,7 @@ inputs:
   prerelease:
     description: "Identify the release as a prerelease. Defaults to false"
     required: false
-    default: ${{ github.event.release.prerelease }}
+    default: ${{ github.event && gitub.event.release ? github.event.release.prerelease : null}}
   files:
     description: "Newline-delimited list of path globs for asset files to upload"
     required: false


### PR DESCRIPTION
When using the Gitea UI to create an release the fields "name", "body" and "prerelease" are no longer overwritten with empty values. The existing data is used by default.