### PR TITLE
Use encodeURIComponent for Tag Name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -48170,6 +48170,7 @@ async function run() {
       BASE: `${server_url}/api/v1`,
       WITH_CREDENTIALS: true,
       TOKEN: token,
+      ENCODE_PATH: encodeURIComponent,
     });
 
     const response = await createOrGetRelease(gitea_client, owner, repo, {
@@ -48210,7 +48211,7 @@ async function createOrGetRelease(client, owner, repo, body) {
     let release = await client.repository.repoGetReleaseByTag({
       owner: owner,
       repo: repo,
-      tag: encodeURIComponent(body.tag_name),
+      tag: body.tag_name,
     })
     const release_id = release.id;
     let target_commitish = release.target_commitish;

--- a/dist/index.js
+++ b/dist/index.js
@@ -48206,10 +48206,11 @@ async function run() {
  */
 async function createOrGetRelease(client, owner, repo, body) {
   try {
+    console.log(`Checking for existing release at ${encodeURIComponent(body.tag)}`);
     let release = await client.repository.repoGetReleaseByTag({
       owner: owner,
       repo: repo,
-      tag: body.tag_name,
+      tag: encodeURIComponent(body.tag_name),
     })
     const release_id = release.id;
     let target_commitish = release.target_commitish;

--- a/dist/index.js
+++ b/dist/index.js
@@ -48206,7 +48206,7 @@ async function run() {
  */
 async function createOrGetRelease(client, owner, repo, body) {
   try {
-    console.log(`Checking for existing release at ${encodeURIComponent(body.tag)}`);
+    console.log(`Checking for existing release at ${encodeURIComponent(body.tag_name)}`);
     let release = await client.repository.repoGetReleaseByTag({
       owner: owner,
       repo: repo,

--- a/main.js
+++ b/main.js
@@ -70,7 +70,7 @@ async function run() {
  */
 async function createOrGetRelease(client, owner, repo, body) {
   try {
-    console.log(`Checking for existing release at ${encodeURIComponent(body.tag)}`);
+    console.log(`Checking for existing release at ${encodeURIComponent(body.tag_name)}`);
     let release = await client.repository.repoGetReleaseByTag({
       owner: owner,
       repo: repo,

--- a/main.js
+++ b/main.js
@@ -70,6 +70,7 @@ async function run() {
  */
 async function createOrGetRelease(client, owner, repo, body) {
   try {
+    console.log(`Checking for existing release at ${encodeURIComponent(body.tag)}`);
     let release = await client.repository.repoGetReleaseByTag({
       owner: owner,
       repo: repo,

--- a/main.js
+++ b/main.js
@@ -34,6 +34,7 @@ async function run() {
       BASE: `${server_url}/api/v1`,
       WITH_CREDENTIALS: true,
       TOKEN: token,
+      ENCODE_PATH: encodeURIComponent,
     });
 
     const response = await createOrGetRelease(gitea_client, owner, repo, {
@@ -74,7 +75,7 @@ async function createOrGetRelease(client, owner, repo, body) {
     let release = await client.repository.repoGetReleaseByTag({
       owner: owner,
       repo: repo,
-      tag: encodeURIComponent(body.tag_name),
+      tag: body.tag_name,
     })
     const release_id = release.id;
     let target_commitish = release.target_commitish;

--- a/main.js
+++ b/main.js
@@ -73,7 +73,7 @@ async function createOrGetRelease(client, owner, repo, body) {
     let release = await client.repository.repoGetReleaseByTag({
       owner: owner,
       repo: repo,
-      tag: body.tag_name,
+      tag: encodeURIComponent(body.tag_name),
     })
     const release_id = release.id;
     let target_commitish = release.target_commitish;

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.2.tgz",
       "integrity": "sha512-cZUy1gUvd4vttMic7C0lwPed8IYXWYp8kHIMatyhY8t8n3Cpw2ILczkV5pGMPqef7v0bLo0pOHrEHarsau2Ydg==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.0.0",


### PR DESCRIPTION
Fixes #11 by using `encodeURIComponent` instead of the Gitea API library's default `encodeURI`. This ensures that tag names containing a forward slash have it replaced by `%2F` in the API URL.